### PR TITLE
Fix API escaping, simplify escaping code

### DIFF
--- a/api/tx/api_frame.go
+++ b/api/tx/api_frame.go
@@ -38,7 +38,7 @@ func escape(p ...byte) []byte {
 	var b bytes.Buffer
 	for _, c := range p {
 		if api.ShouldEscape(c) {
-			b.WriteByte(api.ESCChar)
+			b.WriteByte(api.ESC)
 			b.WriteByte(api.Escape(c))
 		} else {
 			b.WriteByte(c)

--- a/api/tx/api_frame.go
+++ b/api/tx/api_frame.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"bytes"
+
 	"github.com/pauleyj/gobee/api"
 )
 
@@ -19,22 +20,22 @@ func (f *APIFrame) Bytes(frame Frame) ([]byte, error) {
 
 	var b bytes.Buffer
 	b.WriteByte(api.FrameDelimiter)
-	b.Write(f.encode(uint16ToBytes(uint16(len(p)))...))
-	b.Write(f.encode(p...))
+	b.Write(f.encode(uint16ToBytes(uint16(len(p)))))
+	b.Write(f.encode(p))
 	c := checksum(p)
-	b.Write(f.encode(c))
+	b.Write(f.encode([]byte{c}))
 
 	return b.Bytes(), nil
 }
 
-func (f *APIFrame) encode(p ...byte) []byte {
+func (f *APIFrame) encode(p []byte) []byte {
 	if f.Mode == api.EscapeModeInactive {
-		return slicify(p...)
+		return p
 	}
-	return escape(p...)
+	return escape(p)
 }
 
-func escape(p ...byte) []byte {
+func escape(p []byte) []byte {
 	var b bytes.Buffer
 	for _, c := range p {
 		if api.ShouldEscape(c) {
@@ -43,14 +44,6 @@ func escape(p ...byte) []byte {
 		} else {
 			b.WriteByte(c)
 		}
-	}
-	return b.Bytes()
-}
-
-func slicify(p ...byte) []byte {
-	var b bytes.Buffer
-	for _, c := range p {
-		b.WriteByte(c)
 	}
 	return b.Bytes()
 }


### PR DESCRIPTION
This was using `0x20` as the escape byte instead of `0x7D`.